### PR TITLE
Add a python dependancy in  INSTALL file

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,6 +19,7 @@ $ python3 --version
 $ apt install python3-tk python3-unidecode 
 $ pip3 install pymarc
 $ pip3 install SPARQLWrapper
+$ pip3 install lxml
 ```
 
 ## Lancer Bibliostratus


### PR DESCRIPTION
Bonjour,

La librairie lxml est nécessaire au lancement de Bibliostratus. Modification de la page INSTALL en conséquence.

Claire.